### PR TITLE
[NOJIRA] Add Build Time

### DIFF
--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -24,6 +24,7 @@ import { exec } from "../common/exec";
 import { getWorkspaceRelativePath, isFileExists, readJsonFile, removeDirectory, tempFilePath } from "../common/files";
 import { readdir } from "node:fs/promises";
 import { commonLogger } from "../common/logger";
+import { Timer } from "../common/timer";
 
 import { type Command, type TaskTerminal, runTask } from "../common/tasks";
 import { assertUnreachable } from "../common/types";
@@ -50,6 +51,11 @@ import {
 function writeWatchMarkers(terminal: TaskTerminal) {
   terminal.write("🍭 SweetPad: watch marker (start)\n");
   terminal.write("🍩 SweetPad: watch marker (end)\n\n");
+}
+
+function writeTimingResults(terminal: TaskTerminal, timer: Timer, toolType: "xcodebuild" | "bazel", operation: string) {
+  const elapsedSeconds = (timer.elapsed / 1000).toFixed(2);
+  terminal.write(`\n⏱️  ${toolType} ${operation} total time: ${elapsedSeconds}s\n`, { newLine: true });
 }
 
 async function ensureAppPathExists(appPath: string | undefined): Promise<string> {
@@ -591,6 +597,7 @@ export async function buildApp(
     debug: boolean;
   },
 ) {
+  const timer = new Timer();
   vscode.window.showInformationMessage(`Building app for scheme: ${options.scheme}...`);
   terminal.write("Preparing to execute buildApp command...\n");
   const useXcbeatify = isXcbeautifyEnabled() && (await getIsXcbeautifyInstalled());
@@ -648,6 +655,7 @@ export async function buildApp(
     });
 
     await restartSwiftLSP();
+    writeTimingResults(terminal, timer, "xcodebuild", "swift test");
     return;
   }
 
@@ -705,6 +713,13 @@ export async function buildApp(
     }
 
     await restartSwiftLSP();
+    // Determine operation type for timing
+    const operationTypes = [];
+    if (options.shouldClean) operationTypes.push("clean");
+    if (options.shouldBuild) operationTypes.push("build");
+    if (options.shouldTest) operationTypes.push("test");
+    const operation = operationTypes.join(" + ") || "spm";
+    writeTimingResults(terminal, timer, "xcodebuild", operation);
     return;
   }
 
@@ -809,6 +824,14 @@ export async function buildApp(
   }
 
   await restartSwiftLSP();
+
+  // Determine operation type for timing
+  const operationTypes = [];
+  if (options.shouldClean) operationTypes.push("clean");
+  if (options.shouldBuild) operationTypes.push("build");
+  if (options.shouldTest) operationTypes.push("test");
+  const operation = operationTypes.join(" + ") || "build";
+  writeTimingResults(terminal, timer, "xcodebuild", operation);
 
   // Check if periphery scan should run after build
   const runPeripheryAfterBuild = getWorkspaceConfig("periphery.runAfterBuild") ?? false;
@@ -2010,6 +2033,7 @@ export async function bazelBuildCommand(context: ExtensionContext, bazelItem?: B
     lock: "sweetpad.bazel.build",
     terminateLocked: true,
     callback: async (terminal) => {
+      const timer = new Timer();
       terminal.write(`Building Bazel target: ${bazelItem!.target.buildLabel}\n\n`);
 
       // Use terminal.execute for streaming output
@@ -2022,6 +2046,7 @@ export async function bazelBuildCommand(context: ExtensionContext, bazelItem?: B
       });
 
       terminal.write(`\n✅ Build completed for ${bazelItem!.target.name}\n`);
+      writeTimingResults(terminal, timer, "bazel", "build");
     },
   });
 }
@@ -2052,6 +2077,7 @@ export async function bazelTestCommand(context: ExtensionContext, bazelItem?: Ba
     lock: "sweetpad.bazel.test",
     terminateLocked: true,
     callback: async (terminal) => {
+      const timer = new Timer();
       terminal.write(`Running Bazel tests: ${bazelItem!.target.testLabel}\n\n`);
 
       // Use terminal.execute for streaming output
@@ -2061,6 +2087,7 @@ export async function bazelTestCommand(context: ExtensionContext, bazelItem?: Ba
       });
 
       terminal.write(`\n✅ Tests completed for ${bazelItem!.target.name}\n`);
+      writeTimingResults(terminal, timer, "bazel", "test");
     },
   });
 }


### PR DESCRIPTION
## What was implemented:

1. **Added Timer import**: Imported the existing `Timer` class from `../common/timer.ts`

2. **Created timing helper function**: Added `writeTimingResults()` function that formats and prints the timing results with an emoji and clear formatting

3. **Added timing to xcodebuild operations in `buildApp()` function**:
   - **Swift Testing SPM projects**: Shows timing for `swift test` operations
   - **Regular SPM projects**: Shows timing for xcodebuild operations (clean/build/test combinations)
   - **Xcode workspace projects**: Shows timing for xcodebuild operations (clean/build/test combinations)

4. **Added timing to Bazel operations**:
   - **`bazelBuildCommand()`**: Shows timing for bazel build operations
   - **`bazelTestCommand()`**: Shows timing for bazel test operations

## Output format:
The timing results are displayed as:
```
⏱️  xcodebuild build total time: 23.45s
⏱️  bazel test total time: 8.72s  
```

<img width="669" height="711" alt="Screenshot 2025-09-26 at 22 37 34" src="https://github.com/user-attachments/assets/9afbacf4-ce81-490c-93ee-9675997fa07d" />


The timing starts at the beginning of each operation and includes the full build/test execution time. Operations are labeled appropriately (e.g., "build", "test", "clean + build", "swift test").

All changes preserve existing functionality while adding the requested timing information after successful completion of build and test operations.